### PR TITLE
アップロード先指定綴りが間違っているので修正

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -7,9 +7,9 @@ class ImageUploader < CarrierWave::Uploader::Base
   # Choose what kind of storage to use for this uploader:
   # storage :file
   if Rails.env.development?
-    strage :file
+    storage :file
   elsif Rails.env.test?
-    strage :file
+    storage :file
   else
     storage :fog
   end


### PR DESCRIPTION
ローカル環境ではfogを使わないで既存のファイル先に保存する設定にしましたが、
一部綴りが間違っていたので修正しました！
ローカル環境では商品の登録が可能になっていると思います