### PR TITLE
SNSログイン機能 バリデーションのテスト

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 2019_10_19_083809) do
 
   create_table "add_fields_to_user", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -161,9 +160,5 @@ ActiveRecord::Schema.define(version: 2019_10_19_083809) do
   add_foreign_key "item_images", "items"
   add_foreign_key "size_categories", "categories"
   add_foreign_key "size_categories", "sizes"
-
-  
-  add_foreign_key "sizes", "items"
   add_foreign_key "sns_credentials", "users"
-
 end

--- a/spec/factories/sns_credentials.rb
+++ b/spec/factories/sns_credentials.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+
+  factory :sns_credential do
+    uid {"9999999999"}
+    provider {"facebook"}
+    id {1}
+  end
+end

--- a/spec/model/sns_credential_spec.rb
+++ b/spec/model/sns_credential_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+describe SnsCredential do
+  describe '#create' do
+    context "重複の確認" do
+      it "uidとproviderの組み合わせがすでにあれば登録ができない" do
+        sns_credential = create(:sns_credential)
+        another_sns_credential = build(:sns_credential, uid: sns_credential.uid, provider: sns_credential.provider)
+        another_sns_credential.valid?
+        expect(another_sns_credential.errors[:uid]).to include("既に登録があるため登録できません")
+      end
+      it "providerが一致していてもuidが違えば登録できる" do
+        sns_credential = create(:sns_credential)
+        another_sns_credential = build(:sns_credential, uid: "23232323", provider: sns_credential.provider)
+        another_sns_credential.valid?
+        expect(another_sns_credential).to be_valid
+      end
+      it  "uidが一致していてもproviderが違えば登録できる" do
+        sns_credential = create(:sns_credential)
+        another_sns_credential = build(:sns_credential, uid: sns_credential.uid, provider: "Google")
+        another_sns_credential.valid?
+        expect(another_sns_credential).to be_valid
+      end
+    end
+    context "nilの確認" do
+      it 'uidとproviderがnilなら登録できない' do
+        sns_credential = build(:sns_credential, uid: nil, provider: nil)
+        sns_credential.valid?
+        expect(sns_credential.errors[:uid]).to include('を入力してください')
+      end
+      it 'uidがnilなら登録できない' do
+        sns_credential = build(:sns_credential, uid: nil)
+        sns_credential.valid?
+        expect(sns_credential.errors[:uid]).to include('を入力してください')
+      end
+      it 'providerがnilなら登録できない' do
+        sns_credential = build(:sns_credential, provider: nil)
+        sns_credential.valid?
+        expect(sns_credential.errors[:provider]).to include('を入力してください')
+      end
+      it 'user_idがnilなら登録できない' do
+        sns_credential = build(:sns_credential, user_id: nil)
+        sns_credential.valid?
+        expect(sns_credential.errors[:user_id]).to include('を入力してください')
+      end
+      it '全て入力されていれば登録できる' do
+        sns_credential = build(:sns_credential)
+        expect(sns_credential).to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
#What
SNSログイン機能におけるバリデーションのテストを実施。
#Why
sns_credentialモデルが正常にユーザの情報を取得しているか、factorybotのデータを使用し、７パターンのテストコードを用いて検証を行った。