### PR TITLE
SNSログイン機能実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'factory_bot_rails'
   gem 'rails-controller-testing'
-  gem 'faker' 
+  gem 'faker'
 end
 
 group :development do

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -17,10 +17,12 @@ class Users::RegistrationsController < Devise::RegistrationsController
       user_params.merge(password_confirmation: Devise.friendly_token.first(6))
       #super
       @user = User.new(user_params)
-      sns = SnsCredential.update(user_id:  @user.id)
       password = Devise.friendly_token.first(8)
       @user.password = password
       @user.password_confirmation = password
+      @user.save
+      @updatesns = SnsCredential.last
+      sns = @updatesns.update(user_id:  @user.id)
     else #email登録なら
       #super
       @user = User.new(user_params)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,6 @@
 class User < ApplicationRecord
   ## Include default devise modules. Others available are:
   ## :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-
   has_many :sns_credentials, dependent: :destroy
 
   devise :database_authenticatable, :registerable,


### PR DESCRIPTION
#What
sns_credentialテーブルにおけるuser_id番号の不具合修正

#Why
既存のユーザーに対しても新規登録ユーザーと同じユーザー番号が登録されてしまっていたため